### PR TITLE
disable "no-dupe-class-members" for TS overloads

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -37,6 +37,7 @@ module.exports = {
     "@typescript-eslint/triple-slash-reference": "error",
     "@typescript-eslint/type-annotation-spacing": "error",
     "no-var": "error",
+    "no-dupe-class-members": "off",
     "prefer-const": "error",
     "prefer-rest-params": "error",
     "prefer-spread": "error",


### PR DESCRIPTION
This triggers a false-positive on Typescript overloads as they're removed at compile time:

```typescript
    public plus(hbar: Hbar): Hbar;
    public plus(amount: number | BigNumber, unit: HbarUnit): Hbar;
    public plus(amount: Hbar | number | BigNumber, unit?: HbarUnit): Hbar {
        if (amount instanceof Hbar) {
            return new Hbar(this.tinybar.plus(amount.tinybar));
        } else {
            return new Hbar(this.tinybar.plus(convertToTinybar(amount, unit!)));
        }
    }
```


TS itself forbids duplicate class members anyway.